### PR TITLE
Converted strings to string items

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,8 +94,19 @@ Group:Number:COUNT(ON)        gBatteryLow                                   "Emp
 Group:Number:COUNT(OPEN)      gWindowsOpen                                  "Windows Open"                                         
 Group:Number:COUNT(OPEN)      gDoorsOpen                                    "Doors Open"                                           
 Group:Number:COUNT(ON)        gMotionDetected                               "Motion Detected"                                      
+String                        semanticHomeMenu_home                         "Your translation of 'Home'"
+String                        semanticHomeMenu_floors                       "Your translation of 'Floors'"
+String                        semanticHomeMenu_rooms                        "Your translation of 'Rooms'"
+String                        semanticHomeMenu_security                     "Your translation of 'Security'"
+String                        semanticHomeMenu_scenes                       "Your translation of 'Scenes'"
+String                        semanticHomeMenu_appliances                   "Your translation of 'Appliances'"
+String                        semanticHomeMenu_energy                       "Your translation of 'Energy'"
+String                        semanticHomeMenu_system                       "Your translation of 'System'"
+String                        semanticHomeMenu_lights                       "Your translation of 'Lights'"
+String                        semanticHomeMenu_rollers                      "Your translation of 'Rollers'"
+String                        semanticHomeMenu_climate                      "Your translation of 'Climate'"
 ```
-These items will create the general structure shown in the top navigation menu and will also create the red notification badges in the bottom navigation bar.
+These items will create the general structure shown in the top navigation menu and will also create the red notification badges in the bottom navigation bar. Don't forget to set the string items to their correct value e.g. using the openhab console (with command `openhab:update semanticHomeMenu_home Home`).
 
 ## Community
 Please check [openHAB community]for discussions and proposals.

--- a/energy/semanticHomeMenu_Energy.md
+++ b/energy/semanticHomeMenu_Energy.md
@@ -2,7 +2,7 @@
   
 ![grafik](https://github.com/hmerk/semanticHomeMenu/blob/main/screenshots/LowBattery.jpg)
 
-The Eergy widget card used by semanticHomeMenu will by default show information about empty batteries as an accordion list.
+The Energy widget card used by semanticHomeMenu will by default show information about empty batteries as an accordion list.
 
 ![grafik](https://github.com/hmerk/semanticHomeMenu/blob/main/screenshots/LowBatteryExpanded.jpg)
 
@@ -11,17 +11,18 @@ Example for textual item import (TBD)
 ```csv
 Group                   hvacChild               "HVAC Childroom"       <climate>            (Childroom) ["HVAC"]    {uiSemantics="uiSemantics"[preposition=" in the ", equipment="HVAC", location="Childroom"]}
 
-Switch                  powerHvacChild          "HVAC Power"           <switch>             (hvacChild) ["Control", "Power"]
-Number:Temperature      targetTempHvacChild     "Target Temperature"   <temperature>        (hvacChild) ["Setpoint", "Temperature"]
-Number:Temperature      ambientTempHvacChild    "Ambient Temperature"  <temperature>        (hvacChild) ["Measurement", "Temperature"]
-String                  modeHvacChild           "HVAC Mode"            <temperature_cold>   (hvacChild) ["Control", "Temperature"]
-String                  fanspeedHvacChild       "Fanspeed"             <qualityofservice>   (hvacChild) ["Control", "Wind"]
-String                  vanesHvacChild          "Vanes Position"       <movecontrol>        (hvacChild) ["Control", "Opening"]
+Switch                  powerHvacChild                         "HVAC Power"           <switch>             (hvacChild) ["Control", "Power"]
+Number:Temperature      targetTempHvacChild                    "Target Temperature"   <temperature>        (hvacChild) ["Setpoint", "Temperature"]
+Number:Temperature      ambientTempHvacChild                   "Ambient Temperature"  <temperature>        (hvacChild) ["Measurement", "Temperature"]
+String                  modeHvacChild                          "HVAC Mode"            <temperature_cold>   (hvacChild) ["Control", "Temperature"]
+String                  fanspeedHvacChild                      "Fanspeed"             <qualityofservice>   (hvacChild) ["Control", "Wind"]
+String                  vanesHvacChild                         "Vanes Position"       <movecontrol>        (hvacChild) ["Control", "Opening"]
 // Some devices have numeric values for mode, fanspeed and vanes position, use a number item instead
-// Number               modeHvacChild           "HVAC Mode"            <temperature_cold>   (hvacChild) ["Control", "Temperature"]
-// Number               fanspeedHvacChild       "Fanspeed"             <qualityofservice>   (hvacChild) ["Control", "Wind"]
-// Number               vanesHvacChild          "Vanes Position"       <movecontrol>        (hvacChild) ["Control", "Opening"]
-
+// Number               modeHvacChild                          "HVAC Mode"            <temperature_cold>   (hvacChild) ["Control", "Temperature"]
+// Number               fanspeedHvacChild                      "Fanspeed"             <qualityofservice>   (hvacChild) ["Control", "Wind"]
+// Number               vanesHvacChild                         "Vanes Position"       <movecontrol>        (hvacChild) ["Control", "Opening"]
+String                  semanticHomeMenu_batteryAttention      "Your translation of ' batterie(s) need(s) attention'"
+String                  semanticHomeMenu_batteries             "Your translation of 'Batteries'"
 ```
 
 Control Mode, Fanspeed and Vane Position use Item options. More Information with example for different thermostats will follow.

--- a/energy/semanticHomeMenu_Energy.yaml
+++ b/energy/semanticHomeMenu_Energy.yaml
@@ -32,8 +32,8 @@ slots:
                     style:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
-                    subtitle: =(items.gBatteryLowTotal.state.split('.')[0]) + " batterie(s) need(s) attention"
-                    title: Batteries
+                    subtitle: =(items.gBatteryLowTotal.state.split('.')[0]) + items.semanticHomeMenu_batteryAttention.state
+                    title: =items.semanticHomeMenu_batteries.state
                   slots:
                     accordion:
                       - component: f7-list

--- a/main/semanticHomeMenu.yaml
+++ b/main/semanticHomeMenu.yaml
@@ -154,9 +154,9 @@ slots:
                           for: baseMenu
                           fragment: true
                           in:
-                            - name: Home
-                            - name: Floors
-                            - name: Rooms
+                            - name: =items.semanticHomeMenu_home.state
+                            - name: =items.semanticHomeMenu_floors.state
+                            - name: =items.semanticHomeMenu_rooms.state
                           sourceType: array
                         slots:
                           default:
@@ -993,7 +993,7 @@ slots:
                                             text: =(Number(items.gDoorsOpen.state) + Number(items.gWindowsOpen.state) + Number(items.gSmokeAlarm.state) + Number(items.gMotionDetected.state))
                                   - component: Label
                                     config:
-                                      text: Security
+                                      text: =items.semanticHomeMenu_security.state
                       - component: f7-col
                         config:
                           style:
@@ -1025,7 +1025,7 @@ slots:
                                       icon: iconify:heroicons:rectangle-stack
                                   - component: Label
                                     config:
-                                      text: Scenes
+                                      text: =items.semanticHomeMenu_scenes.state
                       - component: f7-col
                         config:
                           style:
@@ -1057,7 +1057,7 @@ slots:
                                       icon: iconify:bi:plugin
                                   - component: Label
                                     config:
-                                      text: Appliances
+                                      text: =items.semanticHomeMenu_appliances.state
                       - component: f7-col
                         config:
                           style:
@@ -1104,7 +1104,7 @@ slots:
                                             text: =(Number(items.gBatteryLowTotal.state))
                                   - component: Label
                                     config:
-                                      text: Energy
+                                      text: =items.semanticHomeMenu_energy.state
                       - component: f7-col
                         config:
                           style:
@@ -1136,7 +1136,7 @@ slots:
                                       icon: iconify:simple-line-icons:info
                                   - component: Label
                                     config:
-                                      text: System
+                                      text: =items.semanticHomeMenu_system.state
           - component: f7-block
             config:
               class:
@@ -1189,7 +1189,7 @@ slots:
                                       icon: iconify:clarity:lightbulb-line
                                   - component: Label
                                     config:
-                                      text: Lights
+                                      text: =items.semanticHomeMenu_lights.state
                       - component: f7-col
                         config:
                           style:
@@ -1221,7 +1221,7 @@ slots:
                                       icon: iconify:mdi:window-shutter
                                   - component: Label
                                     config:
-                                      text: Rollers
+                                      text: =items.semanticHomeMenu_rollers.state
                       - component: f7-col
                         config:
                           style:
@@ -1253,7 +1253,7 @@ slots:
                                       icon: iconify:ph:thermometer-hot-light
                                   - component: Label
                                     config:
-                                      text: Climate
+                                      text: =items.semanticHomeMenu_climate.state
                       - component: f7-col
                         config:
                           style:
@@ -1285,4 +1285,4 @@ slots:
                                       icon: iconify:bi:plugin
                                   - component: Label
                                     config:
-                                      text: Appliances
+                                      text: =items.semanticHomeMenu_appliances.state

--- a/security/semanticHomeMenu_Security.md
+++ b/security/semanticHomeMenu_Security.md
@@ -12,6 +12,18 @@ This widget card will show the members of your configured security groups and th
 - securityMode
   The securityMode item is of type string item which can have the following states (strings): disarmed, armed-away and armed-home. The state will colorize the icons like shown below [inactive - gray, active green or red]
 
+```csv
+String                        semanticHomeMenu_armedHome                    "Your translation of 'ARMED HOME'"
+String                        semanticHomeMenu_disarmed                     "Your translation of 'DISARMED'"
+String                        semanticHomeMenu_armedAway                    "Your translation of 'ARMED AWAY'"
+String                        semanticHomeMenu_smokeDetectors               "Your translation of 'Smoke Detectors'"
+String                        semanticHomeMenu_motionDetectors              "Your translation of 'Motion Detectors'"
+String                        semanticHomeMenu_surveillance                 "Your translation of 'Surveillance'"
+String                        semanticHomeMenu_blinds                       "Your translation of 'Blinds'"
+String                        semanticHomeMenu_doors                        "Your translation of 'Doors'"
+String                        semanticHomeMenu_windows                      "Your translation of 'Windows'"
+```
+
 ## Changelog
 ### Version 0.2
 ### Version 0.1

--- a/security/semanticHomeMenu_Security.yaml
+++ b/security/semanticHomeMenu_Security.yaml
@@ -59,7 +59,7 @@ slots:
                             --f7-button-text-color: 'themeOptions.dark=="light" ? white : black'
                             font-size: 14px
                             height: auto
-                          text: ARMED HOME
+                          text: =items.semanticHomeMenu_armedHome.state
                 - component: f7-col
                   config:
                     style:
@@ -89,7 +89,7 @@ slots:
                             --f7-button-text-color: 'themeOptions.dark=="light" ? white : black'
                             font-size: 14px
                             height: auto
-                          text: DISARMED
+                          text: =items.semanticHomeMenu_disarmed.state
                 - component: f7-col
                   config:
                     style:
@@ -119,7 +119,7 @@ slots:
                             --f7-button-text-color: 'themeOptions.dark=="light" ? white : black'
                             font-size: 14px
                             height: auto
-                          text: ARMED AWAY
+                          text: =items.semanticHomeMenu_armedAway.state
           - component: f7-list
             config:
               accordionList: true
@@ -134,7 +134,7 @@ slots:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
                       margin-top: 30px
-                    title: Smoke Detectors
+                    title: =items.semanticHomeMenu_smokeDetectors.state
                   slots:
                     accordion:
                       - component: f7-list
@@ -176,7 +176,7 @@ slots:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
                       margin-top: 30px
-                    title: Motion Detectors
+                    title: =items.semanticHomeMenu_motionDetectors.state
                   slots:
                     accordion:
                       - component: f7-list
@@ -219,7 +219,7 @@ slots:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
                       margin-top: 30px
-                    title: Surveillance
+                    title: =items.semanticHomeMenu_surveillance.state
                   slots:
                     accordion:
                       - component: f7-list
@@ -262,7 +262,7 @@ slots:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
                       margin-top: 30px
-                    title: Blinds
+                    title: =items.semanticHomeMenu_blinds.state
                   slots:
                     accordion:
                       - component: f7-list
@@ -305,7 +305,7 @@ slots:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
                       margin-top: 30px
-                    title: Doors
+                    title: =items.semanticHomeMenu_doors.state
                   slots:
                     accordion:
                       - component: f7-list
@@ -347,7 +347,7 @@ slots:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
                       margin-top: 30px
-                    title: Windows
+                    title: =items.semanticHomeMenu_windows.state
                   slots:
                     accordion:
                       - component: f7-list

--- a/weather/semanticHomeMenu_Weather.md
+++ b/weather/semanticHomeMenu_Weather.md
@@ -8,6 +8,7 @@ This Weather Widget was inspired by the iOS Weather Widget.
 No additional configuration is needed. Just create the following Items and change the channels according to your needs.
 Please note, the temperature bars mostly appear after a menu change only. We have to figure out why.
 ```csv
+String                        semanticHomeMenu_municipality                 "The name of your municipality"
 Group                       owmWeather                                                      "Weather Data"                        <climate>                                                                   ["WeatherService"]
 Group:Number:Temperature:MIN  minTempForecastDays                                           "Minimum forecasted temperature for next 6 days"                  
 Group:Number:Temperature:MAX  maxTempForecastDays                                           "Maximum forecasted temperature for next 6 days"                  

--- a/weather/semanticHomeMenu_Weather.yaml
+++ b/weather/semanticHomeMenu_Weather.yaml
@@ -43,7 +43,7 @@ slots:
                         config:
                           style:
                             font-size: 16px
-                          text: =items.Localweatherandforecast_StationName.state
+                          text: '=items.Localweatherandforecast_StationName.state != "NULL" ? items.Localweatherandforecast_StationName.state : items.semanticHomeMenu_municipality.state'
                 - component: f7-row
                   config:
                     class:


### PR DESCRIPTION
I thought it would make configuration easier if strings weren't hardcoded, but retrieved from string items. It would also make code updates not break translations.

After I had completed this overhaul, I thought that that was maybe not done by design, to reduce calculation time. But then again, maybe these few operations won't have that big of an impact?