### PR TITLE
Some added if-statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The red indicator badges are shown if there is any alarm, whether security or lo
   * [Weather forecast](https://community.openhab.org/t/oh3-main-ui-examples/117928/30)
   
 ### Usage
-For complete usage of this project, you need to create some groups (equiments) in your semantic model, see the following example for textual item import (change to your individual needs)
+For complete usage of this project, you need to create some groups (equiments) in your semantic model, see the following example for textual item import (change to your individual needs). These items will create the general structure shown in the top navigation menu and will also create the red notification badges in the bottom navigation bar.
 ```csv
 Group                         gHome                                         "Home"                                                                                                       ["Building"]
 Group                         gIndoor                                       "Building"                       <house>               (gHome)                                               ["Indoor"]
@@ -89,13 +89,20 @@ Group                         gHobbyroom                                    "Hob
 Group                         gGarden                                       "Garden"                         <garden>              (gOutdoor)                                            ["Garden"]                         {widgetOrder="51"}
 Group                         gShed                                         "Shed"                           <garden>              (gOutdoor)                                            ["Location"]                       {uiSemantics="uiSemantics"[preposition=" in the ", equipment="Shed", location="Garden"],widgetOrder="52"}
 Group                         gTerrace                                      "Terrace"                        <terrace>             (gOutdoor)                                            ["Room"]                           {uiSemantics="uiSemantics"[preposition=" in the ", equipment="Terrace", location="Garden"],widgetOrder="53"}
+269
+```
+
+For some group items of the security widget, you might not have member items. You should still make the group items, otherwise you'll receive a lot of log entries like `[WARN] ... Attempting to send a state update of an item which doesn't exist: gDoorsOpen`.
+These categories will be invisible in the security widget though, as long as the state of the empty group items is `0.0`. That is the state that openHAB gives to empty group items. However, it's possible this doesn't happen immediately, so you might want to update these states yourself (e.g. in the console with command `openhab:update gBlindsOpen 0.0`).
+```
 Group:Number:COUNT(ON)        gSmokeAlarm                                   "Smokealarm"                     <smoke>
 Group:Number:COUNT(ON)        gBatteryLow                                   "Empty Batteries"                <lowbattery>
 Group:Number:COUNT(OPEN)      gWindowsOpen                                  "Windows Open"                                         
 Group:Number:COUNT(OPEN)      gDoorsOpen                                    "Doors Open"                                           
 Group:Number:COUNT(ON)        gMotionDetected                               "Motion Detected"                                      
+Group:Number:COUNT(ON)        gCamerasDetecting                             "Cameras Detecting something"                          
+Group:Number:COUNT(ON)        gBlindsOpen                                   "Blinds open"                                          
 ```
-These items will create the general structure shown in the top navigation menu and will also create the red notification badges in the bottom navigation bar.
 
 ## Community
 Please check [openHAB community]for discussions and proposals.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The red indicator badges are shown if there is any alarm, whether security or lo
   * [Weather forecast](https://community.openhab.org/t/oh3-main-ui-examples/117928/30)
   
 ### Usage
-For complete usage of this project, you need to create some groups (equiments) in your semantic model, see the following example for textual item import (change to your individual needs). These items will create the general structure shown in the top navigation menu and will also create the red notification badges in the bottom navigation bar.
+For complete usage of this project, you need to create some groups (equiments) in your semantic model, see the following example for textual item import (change to your individual needs).
 ```csv
 Group                         gHome                                         "Home"                                                                                                       ["Building"]
 Group                         gIndoor                                       "Building"                       <house>               (gHome)                                               ["Indoor"]
@@ -91,6 +91,19 @@ Group                         gShed                                         "She
 Group                         gTerrace                                      "Terrace"                        <terrace>             (gOutdoor)                                            ["Room"]                           {uiSemantics="uiSemantics"[preposition=" in the ", equipment="Terrace", location="Garden"],widgetOrder="53"}
 269
 ```
+
+For some group items of the security widget, you might not have member items. You should still make the group items, otherwise you'll receive a lot of log entries like `[WARN] ... Attempting to send a state update of an item which doesn't exist: gDoorsOpen`.
+These categories will be invisible in the security widget though, as long as the state of the empty group items is `0.0`. That is the state that openHAB gives to empty group items. However, it's possible this doesn't happen immediately, so you might want to update these states yourself (e.g. in the console with command `openhab:update gBlindsOpen 0.0`).
+```
+Group:Number:COUNT(ON)        gSmokeAlarm                                   "Smokealarm"                     <smoke>
+Group:Number:COUNT(ON)        gBatteryLow                                   "Empty Batteries"                <lowbattery>
+Group:Number:COUNT(OPEN)      gWindowsOpen                                  "Windows Open"                                         
+Group:Number:COUNT(OPEN)      gDoorsOpen                                    "Doors Open"                                           
+Group:Number:COUNT(ON)        gMotionDetected                               "Motion Detected"                                      
+Group:Number:COUNT(ON)        gCamerasDetecting                             "Cameras Detecting something"                          
+Group:Number:COUNT(ON)        gBlindsOpen                                   "Blinds open"                                          
+```
+All these items will create the general structure shown in the top navigation menu and will also create the red notification badges in the bottom navigation bar.
 
 ## Community
 Please check [openHAB community]for discussions and proposals.

--- a/README.md
+++ b/README.md
@@ -92,18 +92,6 @@ Group                         gTerrace                                      "Ter
 269
 ```
 
-For some group items of the security widget, you might not have member items. You should still make the group items, otherwise you'll receive a lot of log entries like `[WARN] ... Attempting to send a state update of an item which doesn't exist: gDoorsOpen`.
-These categories will be invisible in the security widget though, as long as the state of the empty group items is `0.0`. That is the state that openHAB gives to empty group items. However, it's possible this doesn't happen immediately, so you might want to update these states yourself (e.g. in the console with command `openhab:update gBlindsOpen 0.0`).
-```
-Group:Number:COUNT(ON)        gSmokeAlarm                                   "Smokealarm"                     <smoke>
-Group:Number:COUNT(ON)        gBatteryLow                                   "Empty Batteries"                <lowbattery>
-Group:Number:COUNT(OPEN)      gWindowsOpen                                  "Windows Open"                                         
-Group:Number:COUNT(OPEN)      gDoorsOpen                                    "Doors Open"                                           
-Group:Number:COUNT(ON)        gMotionDetected                               "Motion Detected"                                      
-Group:Number:COUNT(ON)        gCamerasDetecting                             "Cameras Detecting something"                          
-Group:Number:COUNT(ON)        gBlindsOpen                                   "Blinds open"                                          
-```
-
 ## Community
 Please check [openHAB community]for discussions and proposals.
 

--- a/main/semanticHomeMenu.yaml
+++ b/main/semanticHomeMenu.yaml
@@ -654,8 +654,7 @@ slots:
                       - component: widget:semanticHomeMenu_Scenes
                         config:
                           colorScheme: var(--my-text-colorScheme)
-                          sceneName: =loop.scene.name
-                          sceneUID: =loop.scene.UID
+                          sceneJSON: =loop.scene
                           visible: '=vars.objVar ? ((vars.objVar.selectSection + vars.objVar.selectThing)=="SECTION0Scenes") ? true : false : false'
                 - component: widget:semanticHomeMenu_Appliances
                   config:

--- a/scenes/semanticHomeMenu_Scenes.yaml
+++ b/scenes/semanticHomeMenu_Scenes.yaml
@@ -3,14 +3,9 @@ tags: []
 props:
   parameters:
     - context: Text
-      label: UID of the scene to run
-      name: sceneUID
-      required: true
-      type: TEXT
-    - context: Text
       default: WakeUp
-      label: Name (description) of the scene to run
-      name: sceneName
+      label: JSON object of the scene to run
+      name: sceneJSON
       required: true
       type: TEXT
     - context: Text
@@ -73,7 +68,7 @@ slots:
                           style:
                             font-size: 16px
                             font-weight: bold
-                          text: '=props.sceneName ? props.sceneName : "TBD"'
+                          text: '=props.sceneJSON.name ? props.sceneJSON.name : "Nameless scene"'
                 - component: f7-row
                   config:
                     class:
@@ -100,7 +95,7 @@ slots:
                 - component: oh-button
                   config:
                     action: rule
-                    actionRule: =props.sceneUID
+                    actionRule: '=props.sceneJSON.UID ? props.sceneJSON.UID : props.sceneJSON.uid ? props.sceneJSON.uid : "Error: props.sceneJSON.UID nor props.sceneJSON.uid exist"'
                     style:
                       background: =props.colorScheme
                       border-radius: 20px

--- a/security/semanticHomeMenu_Security.md
+++ b/security/semanticHomeMenu_Security.md
@@ -6,19 +6,7 @@
 ![grafik](https://github.com/hmerk/semanticHomeMenu/blob/main/screenshots/SecurityKeypad_dark.jpg)
 
 
-For some group items of the security widget, you might not have member items. You should still make the group items, otherwise you'll receive a lot of log entries like `[WARN] ... Attempting to send a state update of an item which doesn't exist: gDoorsOpen`.
-These categories will be invisible in the security widget though, as long as the state of the empty group items is `0.0`. That is the state that openHAB gives to empty group items. However, it's possible this doesn't happen immediately, so you might want to update these states yourself (e.g. in the console with command `openhab:update gBlindsOpen 0.0`).
-```
-Group:Number:COUNT(ON)        gSmokeAlarm                                   "Smokealarm"                     <smoke>
-Group:Number:COUNT(ON)        gBatteryLow                                   "Empty Batteries"                <lowbattery>
-Group:Number:COUNT(OPEN)      gWindowsOpen                                  "Windows Open"                                         
-Group:Number:COUNT(OPEN)      gDoorsOpen                                    "Doors Open"                                           
-Group:Number:COUNT(ON)        gMotionDetected                               "Motion Detected"                                      
-Group:Number:COUNT(ON)        gCamerasDetecting                             "Cameras Detecting something"                          
-Group:Number:COUNT(ON)        gBlindsOpen                                   "Blinds open"                                          
-```
-
-This widget card will also show the members of your configured security groups and the state of your alarm system. For usage, you will need the following groups and items. If you have an alarm system you want integrated in the widget, the state of `securityGroup_PINused` should be `ON`. If not, the keypad widget will be invisible.
+This widget card will show the members of your configured security groups and the state of your alarm system. For usage, you will need the following groups and items. If you have an alarm system you want integrated in the widget, the state of `securityGroup_PINused` should be `ON`. If not, the keypad widget will be invisible.
 
 - securityGroup
   This group item holds all items of type contact, motion or camera. The state of each item will be shown as a badge. It's essential that item `securityGroup` has the tag `AlarmSystem`.

--- a/security/semanticHomeMenu_Security.md
+++ b/security/semanticHomeMenu_Security.md
@@ -6,11 +6,33 @@
 ![grafik](https://github.com/hmerk/semanticHomeMenu/blob/main/screenshots/SecurityKeypad_dark.jpg)
 
 
-This widget card will show the members of your configured security groups and the state of your alarm system. For usage, you will need the following groups and items in your modell and configured within the main_widget.
-- securityGroup [semantic or non semantic]
-  The security group holds all items of type contact, motion or camera. The state of ech item will be shown as a badge.
-- securityMode
+For some group items of the security widget, you might not have member items. You should still make the group items, otherwise you'll receive a lot of log entries like `[WARN] ... Attempting to send a state update of an item which doesn't exist: gDoorsOpen`.
+These categories will be invisible in the security widget though, as long as the state of the empty group items is `0.0`. That is the state that openHAB gives to empty group items. However, it's possible this doesn't happen immediately, so you might want to update these states yourself (e.g. in the console with command `openhab:update gBlindsOpen 0.0`).
+```
+Group:Number:COUNT(ON)        gSmokeAlarm                                   "Smokealarm"                     <smoke>
+Group:Number:COUNT(ON)        gBatteryLow                                   "Empty Batteries"                <lowbattery>
+Group:Number:COUNT(OPEN)      gWindowsOpen                                  "Windows Open"                                         
+Group:Number:COUNT(OPEN)      gDoorsOpen                                    "Doors Open"                                           
+Group:Number:COUNT(ON)        gMotionDetected                               "Motion Detected"                                      
+Group:Number:COUNT(ON)        gCamerasDetecting                             "Cameras Detecting something"                          
+Group:Number:COUNT(ON)        gBlindsOpen                                   "Blinds open"                                          
+```
+
+This widget card will also show the members of your configured security groups and the state of your alarm system. For usage, you will need the following groups and items. If you have an alarm system you want integrated in the widget, the state of `securityGroup_PINused` should be `ON`. If not, the keypad widget will be invisible.
+
+- securityGroup
+  This group item holds all items of type contact, motion or camera. The state of each item will be shown as a badge. It's essential that item `securityGroup` has the tag `AlarmSystem`.
+- securityGroup_mode
   The securityMode item is of type string item which can have the following states (strings): disarmed, armed-away and armed-home. The state will colorize the icons like shown below [inactive - gray, active green or red]
+- securityGroup_PIN
+  (no idea...)
+
+```
+Group        securityGroup                      "Security Group"               ["AlarmSystem"]
+Switch       securityGroup_PINused              "Security Group - PIN used?"
+String       securityGroup_mode                 "Security Group - Mode"
+String       securityGroup_PIN                  "Security Group - PIN"
+```
 
 ## Changelog
 ### Version 0.2

--- a/security/semanticHomeMenu_Security.yaml
+++ b/security/semanticHomeMenu_Security.yaml
@@ -124,6 +124,7 @@ slots:
             config:
               accordionList: true
               mediaList: true
+              visible: '=items.gSmokeAlarm.state != "0.0" ? "true" : "false"'
             slots:
               default:
                 - component: oh-list-item
@@ -166,6 +167,7 @@ slots:
             config:
               accordionList: true
               mediaList: true
+              visible: '=items.gMotionDetected.state != "0.0" ? "true" : "false"'
             slots:
               default:
                 - component: oh-list-item
@@ -191,7 +193,6 @@ slots:
                                 accordionList: true
                                 cacheSource: true
                                 fetchMetadata: semantics,widgetOrder,uiSemantics
-                                filter: '(loop.motionDetector.category=="motion") ? true : false'
                                 for: motionDetector
                                 fragment: true
                                 groupItem: gMotionDetected
@@ -209,6 +210,7 @@ slots:
             config:
               accordionList: true
               mediaList: true
+              visible: '=items.gCamerasDetecting.state != "0.0" ? "true" : "false"'
             slots:
               default:
                 - component: oh-list-item
@@ -234,11 +236,10 @@ slots:
                                 accordionList: true
                                 cacheSource: true
                                 fetchMetadata: semantics,widgetOrder,uiSemantics
-                                filter: '(loop.surveilance.category=="switch") || (loop.surveilance.category=="Switch") ? true : false'
                                 for: surveilance
                                 fragment: true
-                                itemTags: Camera
-                                sourceType: itemsWithTags
+                                groupItem: gCamerasDetecting
+                                sourceType: itemsInGroup
                               slots:
                                 default:
                                   - component: oh-list-item
@@ -252,6 +253,7 @@ slots:
             config:
               accordionList: true
               mediaList: true
+              visible: '=items.gBlindsOpen.state != "0.0" ? "true" : "false"'
             slots:
               default:
                 - component: oh-list-item
@@ -277,11 +279,10 @@ slots:
                                 accordionList: true
                                 cacheSource: true
                                 fetchMetadata: semantics,widgetOrder,uiSemantics
-                                filter: '((loop.shadesMember.category == "rollershutter") || ((loop.shadesMember.category).includes("Rollershutter"))) ? true : false'
                                 for: shadesMember
                                 fragment: true
-                                itemTags: Opening
-                                sourceType: itemsWithTags
+                                groupItem: gBlindsOpen
+                                sourceType: itemsInGroup
                               slots:
                                 default:
                                   - component: oh-list-item
@@ -295,6 +296,7 @@ slots:
             config:
               accordionList: true
               mediaList: true
+              visible: '=items.gDoorsOpen.state != "0.0" ? "true" : "false"'
             slots:
               default:
                 - component: oh-list-item
@@ -337,6 +339,7 @@ slots:
             config:
               accordionList: true
               mediaList: true
+              visible: '=items.gWindowsOpen.state != "0.0" ? "true" : "false"'
             slots:
               default:
                 - component: oh-list-item

--- a/security/semanticHomeMenu_Security.yaml
+++ b/security/semanticHomeMenu_Security.yaml
@@ -26,6 +26,7 @@ slots:
         default:
           - component: f7-row
             config:
+              visible: '=items.securityGroup_PINused.state == "ON" ? "true" : "false"'
               style:
                 justify-content: space-between
             slots:


### PR DESCRIPTION
As discussed [here](https://community.openhab.org/t/semantichomemenu-for-openhab-4-discussions/152202/192) and [here](https://community.openhab.org/t/semantichomemenu-for-openhab-4-discussions/152202/222), there was room for some more "if" cases.

For the scene UID, I didn't know where exactly to have the "processing" of the if statements take place. I went with "postponing" the calculation for when the actual scenes widget, rather than in the main widget.

I reworked the architecture a bit, so non-relevant categories become invisible in the security widget. Furthermore, I deleted the `filter` configuration, since the group items should only contain relevant items.