### PR TITLE
Translations via string items

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,87 @@ Group:Number:COUNT(ON)        gSmokeAlarm                                   "Smo
 Group:Number:COUNT(ON)        gBatteryLow                                   "Empty Batteries"                <lowbattery>
 Group:Number:COUNT(OPEN)      gWindowsOpen                                  "Windows Open"                                         
 Group:Number:COUNT(OPEN)      gDoorsOpen                                    "Doors Open"                                           
-Group:Number:COUNT(ON)        gMotionDetected                               "Motion Detected"                                      
+Group:Number:COUNT(ON)        gMotionDetected                               "Motion Detected"
 ```
-These items will create the general structure shown in the top navigation menu and will also create the red notification badges in the bottom navigation bar.
+
+### Translatable strings
+Most of the labels in the widget are retrieved from items, but there are also some default labels, which are in English. If you want to keep them in English, you can leave the state of the string items below as `NULL`; then the default labels will appear. Technically, they will also appear if you don't create these string items, but then your log will see a lot of entries like this:
+```
+22:15:13.036 [WARN ] [se.internal.SseItemStatesEventBuilder] - Attempting to send a state update of an item which doesn't exist: semanticHomeMenu_home
+```
+Add these items:
+```
+Group                         gSemanticHomeMenu_strings                     "Strings for the semanticHomeMenu"
+String                        semanticHomeMenu_home                         "semanticHomeMenu string for 'Home'"                             (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_floors                       "semanticHomeMenu string for 'Floors'"                           (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_rooms                        "semanticHomeMenu string for 'Rooms'"                            (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_security                     "semanticHomeMenu string for 'Security'"                         (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_scenes                       "semanticHomeMenu string for 'Scenes'"                           (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_appliances                   "semanticHomeMenu string for 'Appliances'"                       (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_energy                       "semanticHomeMenu string for 'Energy'"                           (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_system                       "semanticHomeMenu string for 'System'"                           (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_lights                       "semanticHomeMenu string for 'Lights'"                           (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_rollers                      "semanticHomeMenu string for 'Rollers'"                          (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_climate                      "semanticHomeMenu string for 'Climate'"                          (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_batteryAttention             "semanticHomeMenu string for ' batterie(s) need(s) attention'"   (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_batteries                    "semanticHomeMenu string for 'Batteries'"                        (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_armedHome                    "semanticHomeMenu string for 'ARMED HOME'"                       (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_disarmed                     "semanticHomeMenu string for 'DISARMED'"                         (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_armedAway                    "semanticHomeMenu string for 'ARMED AWAY'"                       (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_smokeDetectors               "semanticHomeMenu string for 'Smoke Detectors'"                  (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_motionDetectors              "semanticHomeMenu string for 'Motion Detectors'"                 (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_surveillance                 "semanticHomeMenu string for 'Surveillance'"                     (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_blinds                       "semanticHomeMenu string for 'Blinds'"                           (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_doors                        "semanticHomeMenu string for 'Doors'"                            (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_windows                      "semanticHomeMenu string for 'Windows'"                          (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_noMotion                     "semanticHomeMenu string for 'NO-Motion'"                        (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_motion                       "semanticHomeMenu string for 'MOTION'"                           (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_open                         "semanticHomeMenu string for 'OPEN'"                             (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_closed                       "semanticHomeMenu string for 'CLOSED'"                           (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_alarm                        "semanticHomeMenu string for 'ALARM'"                            (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_ok                           "semanticHomeMenu string for 'OK'"                               (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_on                           "semanticHomeMenu string for 'ON'"                               (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_off                          "semanticHomeMenu string for 'OFF'"                              (gSemanticHomeMenu_strings)
+String                        semanticHomeMenu_municipality                 "The name of your municipality"                                  (gSemanticHomeMenu_strings)
+```
+
+If you want to use translated labels, update their state e.g. by running a script like this JavaScript code:
+```js
+var stringarray = [
+  ['semanticHomeMenu_home', 'the string of your choice'],
+  ['semanticHomeMenu_floors', 'the string of your choice'],
+  ['semanticHomeMenu_rooms', 'the string of your choice'],
+  ['semanticHomeMenu_security', 'the string of your choice'],
+  ['semanticHomeMenu_scenes', 'the string of your choice'],
+  ['semanticHomeMenu_appliances', 'the string of your choice'],
+  ['semanticHomeMenu_energy', 'the string of your choice'],
+  ['semanticHomeMenu_system', 'the string of your choice'],
+  ['semanticHomeMenu_lights', 'the string of your choice'],
+  ['semanticHomeMenu_rollers', 'the string of your choice'],
+  ['semanticHomeMenu_climate', 'the string of your choice'],
+  ['semanticHomeMenu_batteryAttention', 'the string of your choice'],
+  ['semanticHomeMenu_batteries', 'the string of your choice'],
+  ['semanticHomeMenu_armedHome', 'the string of your choice'],
+  ['semanticHomeMenu_disarmed', 'the string of your choice'],
+  ['semanticHomeMenu_armedAway', 'the string of your choice'],
+  ['semanticHomeMenu_smokeDetectors', 'the string of your choice'],
+  ['semanticHomeMenu_motionDetectors', 'the string of your choice'],
+  ['semanticHomeMenu_surveillance', 'the string of your choice'],
+  ['semanticHomeMenu_blinds', 'the string of your choice'],
+  ['semanticHomeMenu_doors', 'the string of your choice'],
+  ['semanticHomeMenu_windows', 'the string of your choice'],
+  ['semanticHomeMenu_municipality', 'the string of your choice']
+]
+
+for (var x = 0; x < stringarray.length; x++) {
+  items[stringarray[x][0]].postUpdate(stringarray[x][1])
+}
+```
+
+The drawback of these string items is that  that their value is changed to `NULL` when openHAB restarts. There are few solutions for this problem:
+1. Create a rule that is triggered on a system event (e.g. level 80 (Things initialized)). The code might be the JavaScript code mentioned above.
+2. Install and configure [`MapDB` persistence](https://www.openhab.org/addons/persistence/mapdb/) to keep track of the latest value of all member items of `gSemanticHomeMenu_strings`, and have these values restored on openHAB restart.
+
 
 ## Community
 Please check [openHAB community]for discussions and proposals.

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ String                        semanticHomeMenu_municipality                 "The
 ```
 
 If you want to use translated labels, update their state e.g. by running a script like this JavaScript code:
-```js
+```
 var stringarray = [
   ['semanticHomeMenu_home', 'the string of your choice'],
   ['semanticHomeMenu_floors', 'the string of your choice'],

--- a/README.md
+++ b/README.md
@@ -162,7 +162,15 @@ var stringarray = [
   ['semanticHomeMenu_blinds', 'the string of your choice'],
   ['semanticHomeMenu_doors', 'the string of your choice'],
   ['semanticHomeMenu_windows', 'the string of your choice'],
-  ['semanticHomeMenu_municipality', 'the string of your choice']
+  ['semanticHomeMenu_municipality', 'the string of your choice']?
+  ['semanticHomeMenu_noMotion', 'the string of your choice'],
+  ['semanticHomeMenu_motion', 'the string of your choice'],
+  ['semanticHomeMenu_open', 'the string of your choice'],
+  ['semanticHomeMenu_closed', 'the string of your choice'],
+  ['semanticHomeMenu_alarm', 'the string of your choice'],
+  ['semanticHomeMenu_ok', 'the string of your choice'],
+  ['semanticHomeMenu_on', 'the string of your choice'],
+  ['semanticHomeMenu_off', 'the string of your choice'],
 ]
 
 for (var x = 0; x < stringarray.length; x++) {

--- a/energy/semanticHomeMenu_Energy.md
+++ b/energy/semanticHomeMenu_Energy.md
@@ -2,7 +2,7 @@
   
 ![grafik](https://github.com/hmerk/semanticHomeMenu/blob/main/screenshots/LowBattery.jpg)
 
-The Eergy widget card used by semanticHomeMenu will by default show information about empty batteries as an accordion list.
+The Energy widget card used by semanticHomeMenu will by default show information about empty batteries as an accordion list.
 
 ![grafik](https://github.com/hmerk/semanticHomeMenu/blob/main/screenshots/LowBatteryExpanded.jpg)
 

--- a/main/semanticHomeMenu.yaml
+++ b/main/semanticHomeMenu.yaml
@@ -154,9 +154,9 @@ slots:
                           for: baseMenu
                           fragment: true
                           in:
-                            - name: Home
-                            - name: Floors
-                            - name: Rooms
+                            - name: '= (items.semanticHomeMenu_home.state != "-" && items.semanticHomeMenu_home.state != "NULL") ? items.semanticHomeMenu_home.state : "Home"'
+                            - name: '= (items.semanticHomeMenu_floors.state != "-" && items.semanticHomeMenu_floors.state != "NULL") ? items.semanticHomeMenu_floors.state : "Floors"'
+                            - name: '= (items.semanticHomeMenu_rooms.state != "-" && items.semanticHomeMenu_rooms.state != "NULL") ? items.semanticHomeMenu_rooms.state : "Rooms"'
                           sourceType: array
                         slots:
                           default:
@@ -993,7 +993,7 @@ slots:
                                             text: =(Number(items.gDoorsOpen.state) + Number(items.gWindowsOpen.state) + Number(items.gSmokeAlarm.state) + Number(items.gMotionDetected.state))
                                   - component: Label
                                     config:
-                                      text: Security
+                                      text: '= (items.semanticHomeMenu_security.state != "-" && items.semanticHomeMenu_security.state != "NULL") ? items.semanticHomeMenu_security.state : "Security"'
                       - component: f7-col
                         config:
                           style:
@@ -1025,7 +1025,7 @@ slots:
                                       icon: iconify:heroicons:rectangle-stack
                                   - component: Label
                                     config:
-                                      text: Scenes
+                                      text: '= (items.semanticHomeMenu_scenes.state != "-" && items.semanticHomeMenu_scenes.state != "NULL") ? items.semanticHomeMenu_scenes.state : "Scenes"'
                       - component: f7-col
                         config:
                           style:
@@ -1057,7 +1057,7 @@ slots:
                                       icon: iconify:bi:plugin
                                   - component: Label
                                     config:
-                                      text: Appliances
+                                      text: '= (items.semanticHomeMenu_appliances.state != "-" && items.semanticHomeMenu_appliances.state != "NULL") ? items.semanticHomeMenu_appliances.state : "Appliances"'
                       - component: f7-col
                         config:
                           style:
@@ -1104,7 +1104,7 @@ slots:
                                             text: =(Number(items.gBatteryLowTotal.state))
                                   - component: Label
                                     config:
-                                      text: Energy
+                                      text: '= (items.semanticHomeMenu_energy.state != "-" && items.semanticHomeMenu_energy.state != "NULL") ? items.semanticHomeMenu_energy.state : "Energy"'
                       - component: f7-col
                         config:
                           style:
@@ -1136,7 +1136,7 @@ slots:
                                       icon: iconify:simple-line-icons:info
                                   - component: Label
                                     config:
-                                      text: System
+                                      text: '= (items.semanticHomeMenu_system.state != "-" && items.semanticHomeMenu_system.state != "NULL") ? items.semanticHomeMenu_system.state : "System"'
           - component: f7-block
             config:
               class:
@@ -1189,7 +1189,7 @@ slots:
                                       icon: iconify:clarity:lightbulb-line
                                   - component: Label
                                     config:
-                                      text: Lights
+                                      text: '= (items.semanticHomeMenu_lights.state != "-" && items.semanticHomeMenu_lights.state != "NULL") ? items.semanticHomeMenu_lights.state : "Lights"'
                       - component: f7-col
                         config:
                           style:
@@ -1221,7 +1221,7 @@ slots:
                                       icon: iconify:mdi:window-shutter
                                   - component: Label
                                     config:
-                                      text: Rollers
+                                      text: '= (items.semanticHomeMenu_rollers.state != "-" && items.semanticHomeMenu_rollers.state != "NULL") ? items.semanticHomeMenu_rollers.state : "Rollers"'
                       - component: f7-col
                         config:
                           style:
@@ -1253,7 +1253,7 @@ slots:
                                       icon: iconify:ph:thermometer-hot-light
                                   - component: Label
                                     config:
-                                      text: Climate
+                                      text: '= (items.semanticHomeMenu_climate.state != "-" && items.semanticHomeMenu_climate.state != "NULL") ? items.semanticHomeMenu_climate.state : "Climate"'
                       - component: f7-col
                         config:
                           style:
@@ -1285,4 +1285,4 @@ slots:
                                       icon: iconify:bi:plugin
                                   - component: Label
                                     config:
-                                      text: Appliances
+                                      text: '= (items.semanticHomeMenu_appliances.state != "-" && items.semanticHomeMenu_appliances.state != "NULL") ? items.semanticHomeMenu_appliances.state : "Appliances"'

--- a/security/semanticHomeMenu_Security.yaml
+++ b/security/semanticHomeMenu_Security.yaml
@@ -157,7 +157,7 @@ slots:
                                 default:
                                   - component: oh-list-item
                                     config:
-                                      after: '=items[loop.smokeSensorMember.name].state != "ON" ? ((items.semanticHomeMenu_noMotion.state != "-" && items.semanticHomeMenu_noMotion.state != "NULL") ? items.semanticHomeMenu_noMotion.state : "NO-Motion") : ((items.semanticHomeMenu_motion.state != "-" && items.semanticHomeMenu_motion.state != "NULL") ? items.semanticHomeMenu_motion.state : "MOTION")'
+                                      after: '=items[loop.smokeSensorMember.name].state != "ON" ? ((items.semanticHomeMenu_alarm.state != "-" && items.semanticHomeMenu_alarm.state != "NULL") ? items.semanticHomeMenu_alarm.state : "ALARM") : ((items.semanticHomeMenu_ok.state != "-" && items.semanticHomeMenu_ok.state != "NULL") ? items.semanticHomeMenu_ok.state : "OK")'
                                       icon: '=items[loop.smokeSensorMember.name].state != "OFF" ? "iconify:material-symbols:detector-alarm" : "iconify:material-symbols:detector-smoke"'
                                       iconColor: '=items[loop.smokeSensorMember.name].state != "OFF" ? "red" : "gray"'
                                       item: =loop.smokeSensorMember.name

--- a/security/semanticHomeMenu_Security.yaml
+++ b/security/semanticHomeMenu_Security.yaml
@@ -328,7 +328,7 @@ slots:
                                 default:
                                   - component: oh-list-item
                                     config:
-                                      after: '=items[loop.doorMember.name].state != "CLOSED" ((items.semanticHomeMenu_open.state != "-" && items.semanticHomeMenu_open.state != "NULL") ? items.semanticHomeMenu_open.state : "OPEN") : ((items.semanticHomeMenu_closed.state != "-" && items.semanticHomeMenu_closed.state != "NULL") ? items.semanticHomeMenu_closed.state : "CLOSED")'
+                                      after: '=items[loop.doorMember.name].state != "CLOSED" ? ((items.semanticHomeMenu_open.state != "-" && items.semanticHomeMenu_open.state != "NULL") ? items.semanticHomeMenu_open.state : "OPEN") : ((items.semanticHomeMenu_closed.state != "-" && items.semanticHomeMenu_closed.state != "NULL") ? items.semanticHomeMenu_closed.state : "CLOSED")'
                                       icon: material:sensor_door
                                       iconColor: '=items[loop.doorMember.name].state != "CLOSED" ? "red" : "gray"'
                                       item: =loop.doorMember.name
@@ -370,7 +370,7 @@ slots:
                                 default:
                                   - component: oh-list-item
                                     config:
-                                      after: '=items[loop.windowMember.name].state != "CLOSED" ((items.semanticHomeMenu_open.state != "-" && items.semanticHomeMenu_open.state != "NULL") ? items.semanticHomeMenu_open.state : "OPEN") : ((items.semanticHomeMenu_closed.state != "-" && items.semanticHomeMenu_closed.state != "NULL") ? items.semanticHomeMenu_closed.state : "CLOSED")'
+                                      after: '=items[loop.windowMember.name].state != "CLOSED" ? ((items.semanticHomeMenu_open.state != "-" && items.semanticHomeMenu_open.state != "NULL") ? items.semanticHomeMenu_open.state : "OPEN") : ((items.semanticHomeMenu_closed.state != "-" && items.semanticHomeMenu_closed.state != "NULL") ? items.semanticHomeMenu_closed.state : "CLOSED")'
                                       icon: material:sensor_window
                                       iconColor: '=items[loop.windowMember.name].state != "CLOSED" ? "red" : "gray"'
                                       item: =loop.windowMember.name

--- a/security/semanticHomeMenu_Security.yaml
+++ b/security/semanticHomeMenu_Security.yaml
@@ -59,7 +59,7 @@ slots:
                             --f7-button-text-color: 'themeOptions.dark=="light" ? white : black'
                             font-size: 14px
                             height: auto
-                          text: ARMED HOME
+                          text: '= (items.semanticHomeMenu_armedHome.state != "-" && items.semanticHomeMenu_armedHome.state != "NULL") ? items.semanticHomeMenu_armedHome.state : "ARMED HOME"'
                 - component: f7-col
                   config:
                     style:
@@ -89,7 +89,7 @@ slots:
                             --f7-button-text-color: 'themeOptions.dark=="light" ? white : black'
                             font-size: 14px
                             height: auto
-                          text: DISARMED
+                          text: '= (items.semanticHomeMenu_disarmed.state != "-" && items.semanticHomeMenu_disarmed.state != "NULL") ? items.semanticHomeMenu_disarmed.state : "DISARMED"'
                 - component: f7-col
                   config:
                     style:
@@ -119,7 +119,7 @@ slots:
                             --f7-button-text-color: 'themeOptions.dark=="light" ? white : black'
                             font-size: 14px
                             height: auto
-                          text: ARMED AWAY
+                          text: '= (items.semanticHomeMenu_armedAway.state != "-" && items.semanticHomeMenu_armedAway.state != "NULL") ? items.semanticHomeMenu_armedAway.state : "ARMED AWAY"'
           - component: f7-list
             config:
               accordionList: true
@@ -134,7 +134,7 @@ slots:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
                       margin-top: 30px
-                    title: Smoke Detectors
+                    title: '= (items.semanticHomeMenu_smokeDetectors.state != "-" && items.semanticHomeMenu_smokeDetectors.state != "NULL") ? items.semanticHomeMenu_smokeDetectors.state : "Smoke Detectors"'
                   slots:
                     accordion:
                       - component: f7-list
@@ -157,7 +157,7 @@ slots:
                                 default:
                                   - component: oh-list-item
                                     config:
-                                      after: '=items[loop.smokeSensorMember.name].state != "OFF" ? "ALARM" : "OK"'
+                                      after: '=items[loop.smokeSensorMember.name].state != "ON" ? ((items.semanticHomeMenu_noMotion.state != "-" && items.semanticHomeMenu_noMotion.state != "NULL") ? items.semanticHomeMenu_noMotion.state : "NO-Motion") : ((items.semanticHomeMenu_motion.state != "-" && items.semanticHomeMenu_motion.state != "NULL") ? items.semanticHomeMenu_motion.state : "MOTION")'
                                       icon: '=items[loop.smokeSensorMember.name].state != "OFF" ? "iconify:material-symbols:detector-alarm" : "iconify:material-symbols:detector-smoke"'
                                       iconColor: '=items[loop.smokeSensorMember.name].state != "OFF" ? "red" : "gray"'
                                       item: =loop.smokeSensorMember.name
@@ -176,7 +176,7 @@ slots:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
                       margin-top: 30px
-                    title: Motion Detectors
+                    title: '= (items.semanticHomeMenu_motionDetectors.state != "-" && items.semanticHomeMenu_motionDetectors.state != "NULL") ? items.semanticHomeMenu_motionDetectors.state : "Motion Detectors"'
                   slots:
                     accordion:
                       - component: f7-list
@@ -200,7 +200,7 @@ slots:
                                 default:
                                   - component: oh-list-item
                                     config:
-                                      after: '=items[loop.motionDetector.name].state != "ON" ? "NO-Motion" : "MOTION"'
+                                      after: '=items[loop.motionDetector.name].state != "ON" ? ((items.semanticHomeMenu_noMotion.state != "-" && items.semanticHomeMenu_noMotion.state != "NULL") ? items.semanticHomeMenu_noMotion.state : "NO-Motion") : ((items.semanticHomeMenu_motion.state != "-" && items.semanticHomeMenu_motion.state != "NULL") ? items.semanticHomeMenu_motion.state : "MOTION")'
                                       icon: '=items[loop.motionDetector.name].state == "ON" ? "motion-open" : "motion-closed"'
                                       iconColor: '=items[loop.motionDetector.name].state != "ON" ? "red" : "gray"'
                                       item: =loop.motionDetector.name
@@ -219,7 +219,7 @@ slots:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
                       margin-top: 30px
-                    title: Surveillance
+                    title: '= (items.semanticHomeMenu_surveillance.state != "-" && items.semanticHomeMenu_surveillance.state != "NULL") ? items.semanticHomeMenu_surveillance.state : "Surveillance"'
                   slots:
                     accordion:
                       - component: f7-list
@@ -243,7 +243,7 @@ slots:
                                 default:
                                   - component: oh-list-item
                                     config:
-                                      after: '=items[loop.surveilance.name].state != "ON" ? "OFF" : "ON"'
+                                      after: '=items[loop.surveilance.name].state != "ON" ? ((items.semanticHomeMenu_off.state != "-" && items.semanticHomeMenu_off.state != "NULL") ? items.semanticHomeMenu_off.state : "OFF") : ((items.semanticHomeMenu_on.state != "-" && items.semanticHomeMenu_on.state != "NULL") ? items.semanticHomeMenu_on.state : "ON")'
                                       icon: material:video_camera_front
                                       iconColor: '=items[loop.surveilance.name].state != "ON" ? "gray" : "red"'
                                       item: =loop.surveilance.name
@@ -262,7 +262,7 @@ slots:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
                       margin-top: 30px
-                    title: Blinds
+                    title: '= (items.semanticHomeMenu_blinds.state != "-" && items.semanticHomeMenu_blinds.state != "NULL") ? items.semanticHomeMenu_blinds.state : "Blinds"'
                   slots:
                     accordion:
                       - component: f7-list
@@ -286,7 +286,7 @@ slots:
                                 default:
                                   - component: oh-list-item
                                     config:
-                                      after: '=items[loop.shadesMember.name].state != "100" ? "OPEN" : "CLOSED"'
+                                      after: '=items[loop.shadesMember.name].state != "100" ? ((items.semanticHomeMenu_open.state != "-" && items.semanticHomeMenu_open.state != "NULL") ? items.semanticHomeMenu_open.state : "OPEN") : ((items.semanticHomeMenu_closed.state != "-" && items.semanticHomeMenu_closed.state != "NULL") ? items.semanticHomeMenu_closed.state : "CLOSED")'
                                       title: =loop.shadesMember.metadata.uiSemantics.config.location
                                       icon: '=(loop.shadesMember.state == "0") ? "material:roller_shades" : "material:roller_shades"'
                                       iconColor: gray
@@ -305,7 +305,7 @@ slots:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
                       margin-top: 30px
-                    title: Doors
+                    title: '= (items.semanticHomeMenu_doors.state != "-" && items.semanticHomeMenu_doors.state != "NULL") ? items.semanticHomeMenu_doors.state : "Doors"'
                   slots:
                     accordion:
                       - component: f7-list
@@ -328,7 +328,7 @@ slots:
                                 default:
                                   - component: oh-list-item
                                     config:
-                                      after: '=items[loop.doorMember.name].state != "CLOSED" ? "OPEN" : "CLOSED"'
+                                      after: '=items[loop.doorMember.name].state != "CLOSED" ((items.semanticHomeMenu_open.state != "-" && items.semanticHomeMenu_open.state != "NULL") ? items.semanticHomeMenu_open.state : "OPEN") : ((items.semanticHomeMenu_closed.state != "-" && items.semanticHomeMenu_closed.state != "NULL") ? items.semanticHomeMenu_closed.state : "CLOSED")'
                                       icon: material:sensor_door
                                       iconColor: '=items[loop.doorMember.name].state != "CLOSED" ? "red" : "gray"'
                                       item: =loop.doorMember.name
@@ -347,7 +347,7 @@ slots:
                       --f7-list-item-after-font-size: 16px
                       --f7-list-item-after-text-color: "=themeOptions.dark === 'dark' ? 'rgb(180,180,180)' : 'rgb(80,80,80)'"
                       margin-top: 30px
-                    title: Windows
+                    title: '= (items.semanticHomeMenu_windows.state != "-" && items.semanticHomeMenu_windows.state != "NULL") ? items.semanticHomeMenu_windows.state : "Windows"'
                   slots:
                     accordion:
                       - component: f7-list
@@ -370,7 +370,7 @@ slots:
                                 default:
                                   - component: oh-list-item
                                     config:
-                                      after: '=items[loop.windowMember.name].state != "CLOSED" ? "OPEN" : "CLOSED"'
+                                      after: '=items[loop.windowMember.name].state != "CLOSED" ((items.semanticHomeMenu_open.state != "-" && items.semanticHomeMenu_open.state != "NULL") ? items.semanticHomeMenu_open.state : "OPEN") : ((items.semanticHomeMenu_closed.state != "-" && items.semanticHomeMenu_closed.state != "NULL") ? items.semanticHomeMenu_closed.state : "CLOSED")'
                                       icon: material:sensor_window
                                       iconColor: '=items[loop.windowMember.name].state != "CLOSED" ? "red" : "gray"'
                                       item: =loop.windowMember.name

--- a/weather/semanticHomeMenu_Weather.yaml
+++ b/weather/semanticHomeMenu_Weather.yaml
@@ -43,7 +43,7 @@ slots:
                         config:
                           style:
                             font-size: 16px
-                          text: =items.Localweatherandforecast_StationName.state
+                          text: '=items.Localweatherandforecast_StationName.state != "NULL" ? items.Localweatherandforecast_StationName.state : (items.semanticHomeMenu_municipality.state != "-" && items.semanticHomeMenu_municipality.state != "NULL") ? items.semanticHomeMenu_municipality.state : "Your municipality"'
                 - component: f7-row
                   config:
                     class:

--- a/weather/semanticHomeMenu_Weather.yaml
+++ b/weather/semanticHomeMenu_Weather.yaml
@@ -43,7 +43,7 @@ slots:
                         config:
                           style:
                             font-size: 16px
-                          text: '=items.Localweatherandforecast_StationName.state != "NULL" ? items.Localweatherandforecast_StationName.state : (items.semanticHomeMenu_municipality.state != "-" && items.semanticHomeMenu_municipality.state != "NULL") ? items.semanticHomeMenu_municipality.state : "Your municipality"'
+                          text: '= (items.Localweatherandforecast_StationName.state != "-" && items.Localweatherandforecast_StationName.state != "NULL") ? items.Localweatherandforecast_StationName.state : (items.semanticHomeMenu_municipality.state != "-" && items.semanticHomeMenu_municipality.state != "NULL") ? items.semanticHomeMenu_municipality.state : "Your municipality"'
                 - component: f7-row
                   config:
                     class:


### PR DESCRIPTION
I dove into a rabbit hole, and I think I'm now out of it. The suggested changes offer the possibility to translate the labels which are now hardcoded. If a user wants to use the English labels, he can just create the string items and never change them.

There's a bit of extra work for who wants to use translations, but the explanation is added to `README.md`.